### PR TITLE
Update comment to reflect the current (MIT) license on the code.

### DIFF
--- a/mmverify.py
+++ b/mmverify.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 # mmverify.py -- Proof verifier for the Metamath language
 # Copyright (C) 2002 Raph Levien raph (at) acm (dot) org
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License
+# This program is free software distributed under the MIT license;
+# see the file LICENSE for full license information.
 
 # To run the program, type
 #   $ python3 mmverify.py < set.mm 2> set.log


### PR DESCRIPTION
Thanks for hosting this program.

I was a bit confused after first reading the source code and seeing the comment at the top suggesting it's GPL'ed code, but then seeing GitHub list the license as MIT.

After looking around a bit I realised it's been relicensed.  It seems that it's simply that the two lines in the code referring to the GPL did not get updated when that happened.

So, I've opened this pull request to correct that, and hopefully make it a little less confusing for other readers of the code.

(Incidentally, I think it would also be entirely appropriate to mention the historical copyright status in the LICENSE file itself, i.e. to change the 3rd line of LICENSE to something like `Copyright (c) 2002 Raph Levien, (c) 2019 David A. Wheeler`.  However, that is much less of a source of confusion, and is a change I do not feel comfortable with making myself -- so I have not made it part of this PR. I only note it here as my opinion.)