### PR TITLE
Faster

### DIFF
--- a/mmverify.py
+++ b/mmverify.py
@@ -27,10 +27,12 @@ import argparse
 
 
 class MMError(Exception):
+    """Class of Metamath errors."""
     pass
 
 
 class MMKeyError(MMError, KeyError):
+    """Class of Metamath key errors."""
     pass
 
 
@@ -197,10 +199,10 @@ class FrameStack(list):
         return any((min(x, y), max(x, y)) in fr.d for fr in self)
 
     def lookup_f(self, var):
-        """Return the label of the latest active floating hypothesis which
-        types the given variable.
+        """Return the label of the active floating hypothesis which types the
+        given variable.
         """
-        for frame in reversed(self):
+        for frame in self:
             try:
                 return frame.f_labels[var]
             except KeyError:
@@ -208,11 +210,11 @@ class FrameStack(list):
         raise MMKeyError(var)
 
     def lookup_e(self, stmt):
-        """Return the label of the latest active essential hypothesis with the
-        given statement.
+        """Return the label of the (earliest) active essential hypothesis with
+        the given statement.
         """
         stmt_t = tuple(stmt)
-        for frame in reversed(self):
+        for frame in self:
             try:
                 return frame.e_labels[stmt_t]
             except KeyError:

--- a/mmverify.py
+++ b/mmverify.py
@@ -207,11 +207,10 @@ class FrameStack(list):
         frame.e_labels[tuple(stmt)] = label
         # conversion to tuple since dictionary keys must be hashable
 
-    def add_d(self, stmt: Stmt) -> None:
+    def add_d(self, varlist: list[Var]) -> None:
         """Add a disjoint variable condition (ordered pair of variables) to
         the frame stack top.
         """
-        varlist = self.find_vars(stmt)
         self[-1].d.update((min(x, y), max(x, y))
                           for x, y in itertools.product(varlist, varlist) if x != y)
 

--- a/mmverify.py
+++ b/mmverify.py
@@ -389,7 +389,8 @@ class MM:
             npop = len(f_hyps0) + len(e_hyps0)
             sp = len(stack) - npop
             if sp < 0:
-                raise MMError('stack underflow')
+                raise MMError(
+                    "stack underflow: proof step requires too many hypotheses")
             subst: dict[Var, Stmt] = {}
             for typecode, var in f_hyps0:
                 entry = stack[sp]
@@ -502,7 +503,10 @@ class MM:
         else:  # normal format
             stack = self.treat_normal_proof(proof)
         vprint(10, 'stack at end of proof:', stack)
-        if len(stack) != 1:
+        if not stack:
+            raise MMError(
+                "empty stack at end of proof")
+        if len(stack) > 1:
             raise MMError(
                 "Stack has more than one entry at end of proof (top " +
                 "entry: {0!s} ; proved assertion: {1!s}).".format(
@@ -511,6 +515,7 @@ class MM:
         if stack[0] != conclusion:
             raise MMError(("Stack entry {0!s} does not match proved " +
                           " assertion {1!s}").format(stack[0], conclusion))
+        vprint(3, 'correct proof')
 
     def dump(self) -> None:
         """Print the labels of the database."""

--- a/mmverify.py
+++ b/mmverify.py
@@ -83,6 +83,8 @@ class toks:
         tok = self.read()
         while tok == '$[':
             filename = self.read()
+            if not filename:
+                raise MMError('Inclusion command not terminated')
             endbracket = self.read()
             if endbracket != '$]':
                 raise MMError('Inclusion command not terminated')

--- a/mmverify.py
+++ b/mmverify.py
@@ -186,7 +186,7 @@ class FrameStack(list):
         return any((tok in fr.c for fr in self))
 
     def lookup_v(self, tok):
-        """Return whether the given token was defined as a constant in the
+        """Return whether the given token was defined as a variable in the
         current scope.
         """
         return any((tok in fr.v for fr in self))

--- a/mmverify.py
+++ b/mmverify.py
@@ -297,7 +297,7 @@ class MM:
         return vars
 
     def decompress_proof(self, f_hyps, e_hyps, proof):
-        f_labels = [self.fs.lookup_f(v) for k, v in f_hyps]
+        f_labels = [self.fs.lookup_f(v) for _, v in f_hyps]
         e_labels = [self.fs.lookup_e(s) for s in e_hyps]
         labels = f_labels + e_labels
         hyp_end = len(labels)
@@ -330,7 +330,6 @@ class MM:
                 decompressed_ints.append(pf_int)
             elif hyp_end <= pf_int and pf_int < label_end:
                 decompressed_ints.append(pf_int)
-
                 step = self.labels[labels[pf_int]]
                 step_type, step_data = step[0], step[1]
                 if step_type in ('$a', '$p'):
@@ -369,7 +368,7 @@ class MM:
                 if sp < 0:
                     raise MMError('stack underflow')
                 subst = {}
-                for (k, v) in f_hyps0:
+                for k, v in f_hyps0:
                     entry = stack[sp]
                     if entry[0] != k:
                         raise MMError(
@@ -378,17 +377,6 @@ class MM:
                     subst[v] = entry[1:]
                     sp += 1
                 vprint(15, 'subst:', subst)
-                for x, y in dvs0:
-                    vprint(16, 'dist', x, y, subst[x], subst[y])
-                    x_vars = self.find_vars(subst[x])
-                    y_vars = self.find_vars(subst[y])
-                    vprint(16, 'V(x) =', x_vars)
-                    vprint(16, 'V(y) =', y_vars)
-                    for x, y in itertools.product(x_vars, y_vars):
-                        if x == y or not self.fs.lookup_d(x, y):
-                            raise MMError(
-                                "disjoint variable violation: {0}, {1}" .format(
-                                    x, y))
                 for h in e_hyps0:
                     entry = stack[sp]
 # comment either the following four lines, or the next five lines
@@ -402,6 +390,16 @@ class MM:
                                        "essential hypothesis {1!s}")
                                       .format(entry, subst_h))
                     sp += 1
+                for x, y in dvs0:
+                    vprint(16, 'dist', x, y, subst[x], subst[y])
+                    x_vars = self.find_vars(subst[x])
+                    y_vars = self.find_vars(subst[y])
+                    vprint(16, 'V(x) =', x_vars)
+                    vprint(16, 'V(y) =', y_vars)
+                    for x, y in itertools.product(x_vars, y_vars):
+                        if x == y or not self.fs.lookup_d(x, y):
+                            raise MMError(
+                                "disjoint violation: {0}, {1}" .format(x, y))
                 del stack[len(stack) - npop:]
                 stack.append(apply_subst(conclusion0, subst))
             elif steptyp in ('$e', '$f'):

--- a/mmverify.py
+++ b/mmverify.py
@@ -267,8 +267,8 @@ class FrameStack(list[Frame]):
         e_hyps = [eh for fr in self for eh in fr.e]
         mand_vars = {tok for hyp in itertools.chain(e_hyps, [stmt])
                      for tok in hyp if self.lookup_v(tok)}
-        dvs = {(x, y) for fr in self for (x, y) in
-               fr.d.intersection(itertools.product(mand_vars, mand_vars))}
+        dvs = {(x, y) for fr in self for (x, y)
+               in fr.d if x in mand_vars and y in mand_vars}
         f_hyps = []
         # If one allows Metamath databases with multiple $f-statements for a
         # given var, then one should use "reversed" in the next two lines and

--- a/mmverify.py
+++ b/mmverify.py
@@ -476,7 +476,7 @@ class MM:
                 # bloc
                 self.treat_step(self.labels[plabels[proof_int]], stack)
             elif proof_int > n_saved_stmts:
-                MMError("Not enough saved subproofs.")
+                MMError("Not enough saved proof steps.")
             else:  # label_end <= proof_int <= n_saved_stmts
                 # proof_int denotes an earlier proof step marked with a 'Z'
                 # A proof step that has already been proved can be treated as

--- a/mmverify.py
+++ b/mmverify.py
@@ -144,8 +144,8 @@ class FrameStack(list):
         frame.d.update(((min(x, y), max(x, y))
                         for x, y in itertools.product(stat, stat) if x != y))
 
-    def lookup_c(self, tok): return any((tok in fr.c for fr in reversed(self)))
-    def lookup_v(self, tok): return any((tok in fr.v for fr in reversed(self)))
+    def lookup_c(self, tok): return any((tok in fr.c for fr in self))
+    def lookup_v(self, tok): return any((tok in fr.v for fr in self))
 
     def lookup_f(self, var):
         for frame in reversed(self):
@@ -156,7 +156,7 @@ class FrameStack(list):
         raise MMKeyError(var)
 
     def lookup_d(self, x, y):
-        return any(((min(x, y), max(x, y)) in fr.d for fr in reversed(self)))
+        return any(((min(x, y), max(x, y)) in fr.d for fr in self))
 
     def lookup_e(self, stmt):
         stmt_t = tuple(stmt)
@@ -168,7 +168,6 @@ class FrameStack(list):
         raise MMKeyError(stmt_t)
 
     def make_assertion(self, stat):
-        frame = self[-1]
         e_hyps = [eh for fr in self for eh in fr.e]
         mand_vars = {tok for hyp in itertools.chain(e_hyps, [stat])
                      for tok in hyp if self.lookup_v(tok)}
@@ -344,9 +343,8 @@ class MM:
 
         return [labels[i] for i in decompressed_ints]
 
-    def verify(self, stat_label, stat, proof):
+    def verify(self, stat, proof):
         stack = []
-        stat_type = stat[0]
         if proof[0] == '(':
             proof = self.decompress_proof(stat, proof)
 

--- a/mmverify.py
+++ b/mmverify.py
@@ -255,13 +255,9 @@ class FrameStack(list[Frame]):
                 pass
         raise MMKeyError(stmt_t)
 
-    def find_vars(self, stmt: Stmt) -> list[Var]:
-        """Return the list of variables in the given statement."""
-        var_list = []
-        for x in stmt:
-            if x not in var_list and self.lookup_v(x):
-                var_list.append(x)
-        return var_list
+    def find_vars(self, stmt: Stmt) -> set[Var]:
+        """Return the set of variables in the given statement."""
+        return {x for x in stmt if self.lookup_v(x)}
 
     def make_assertion(self, stmt: Stmt) -> Assertion:
         """Return a quadruple (disjoint variable conditions, floating

--- a/mmverify.py
+++ b/mmverify.py
@@ -359,7 +359,7 @@ class MM:
                 vars.append(x)
         return vars
 
-    def step(self, step, stack):
+    def treat_step(self, step, stack):
         """Carry out the given proof step (given the label to treat and the
         current proof stack).  This modifies the given stack in place.
         """
@@ -412,7 +412,7 @@ class MM:
         """
         stack = []
         for label in proof:
-            self.step(self.labels[label], stack)
+            self.treat_step(self.labels[label], stack)
         return stack
 
     def treat_compressed_proof(self, f_hyps, e_hyps, proof):
@@ -451,12 +451,12 @@ class MM:
             elif 0 <= proof_int and proof_int < label_end:
                 # pf_int denotes an implicit hypothesis or a label in the label
                 # bloc
-                self.step(self.labels[labels[proof_int]], stack)
+                self.treat_step(self.labels[labels[proof_int]], stack)
             elif label_end <= proof_int:
                 # pf_int denotes an earlier proof step marked with a 'Z'
                 # A proof step that has already been proved can be treated as
                 # a dv-free and hypothesis-free axiom.
-                self.step(
+                self.treat_step(
                     ('$a', ([], [], [], saved_stmts[proof_int - label_end])), stack)
         return stack
 

--- a/mmverify.py
+++ b/mmverify.py
@@ -5,7 +5,7 @@
 # it under the terms of the GNU General Public License
 
 # To run the program, type
-#   $ python3 mmverify.py < set.mm 2> set.log
+#   $ python3 mmverify.py set.mm 2> set.log
 # and set.log will have the verification results.
 # To get help on the program usage, type
 #   $ python3 mmverify.py -h
@@ -403,15 +403,15 @@ class MM:
                 for h in e_hyps0:
                     entry = stack[sp]
 # comment either the following four lines, or the next five lines
-                    if not equal_subst(h, subst, entry):
-                        raise MMError(("stack entry {0!s} does not match " +
-                                       "essential hypothesis {1!s}")
-                                      .format(entry, apply_subst(h, subst)))
-#                    subst_h = apply_subst(h, subst)
-#                    if entry != subst_h:
+#                    if not equal_subst(h, subst, entry):
 #                        raise MMError(("stack entry {0!s} does not match " +
 #                                       "essential hypothesis {1!s}")
-#                                      .format(entry, subst_h))
+#                                      .format(entry, apply_subst(h, subst)))
+                    subst_h = apply_subst(h, subst)
+                    if entry != subst_h:
+                        raise MMError(("stack entry {0!s} does not match " +
+                                       "essential hypothesis {1!s}")
+                                      .format(entry, subst_h))
                     sp += 1
                 del stack[len(stack) - npop:]
                 stack.append(apply_subst(conclusion0, subst))

--- a/mmverify.py
+++ b/mmverify.py
@@ -459,7 +459,7 @@ class MM:
                 # A proof step that has already been proved can be treated as
                 # a dv-free and hypothesis-free axiom.
                 self.treat_step(
-                    ('$a', ([], [], [], saved_stmts[proof_int - label_end])), stack)
+                    ('$a', (set(), [], [], saved_stmts[proof_int - label_end])), stack)
         return stack
 
     def verify(self, f_hyps, e_hyps, conclusion, proof):

--- a/mmverify.py
+++ b/mmverify.py
@@ -73,13 +73,10 @@ class toks:
     def readc(self):
         while 1:
             tok = self.readf()
-            if tok is None:
-                return None
             if tok == '$(':
                 while tok != '$)':
                     tok = self.read()
-            else:
-                return tok
+            return tok
 
     def readstat(self):
         stat = []

--- a/mmverify.py
+++ b/mmverify.py
@@ -281,8 +281,9 @@ class FrameStack(list[Frame]):
                 if var in mand_vars:
                     f_hyps.append((typecode, var))
                     mand_vars.remove(var)
-        vprint(18, 'make_assertion:', dvs, f_hyps, e_hyps, stmt)
-        return (dvs, f_hyps, e_hyps, stmt)
+        assertion = dvs, f_hyps, e_hyps, stmt
+        vprint(18, 'Make assertion:', assertion)
+        return assertion
 
 
 def apply_subst(stmt: Stmt, subst: dict[Var, Stmt]) -> Stmt:
@@ -371,7 +372,7 @@ class MM:
                          "(statement: {})").format(stmt)) from exc
                 dvs, f_hyps, e_hyps, conclusion = self.fs.make_assertion(stmt)
                 if not self.begin_label:
-                    vprint(2, 'verifying:', label)
+                    vprint(2, 'Verify:', label)
                     self.verify(f_hyps, e_hyps, conclusion, proof)
                 self.labels[label] = ('$p', (dvs, f_hyps, e_hyps, conclusion))
                 label = None
@@ -392,8 +393,8 @@ class MM:
         """Carry out the given proof step (given the label to treat and the
         current proof stack).  This modifies the given stack in place.
         """
+        vprint(10, 'Proof step:', step)
         steptyp, stepdat = step
-        vprint(10, 'Proof step:', steptyp, stepdat)
         if steptyp in ('$e', '$f'):
             stack.append(stepdat)
         elif steptyp in ('$a', '$p'):
@@ -462,8 +463,11 @@ class MM:
         idx_bloc = proof.index(')')  # index of end of label bloc
         plabels += proof[1:idx_bloc]  # labels which will be referenced later
         compressed_proof = ''.join(proof[idx_bloc + 1:])
-        vprint(5, 'labels:', plabels)
-        vprint(5, 'proof:', compressed_proof)
+        vprint(5, 'Referenced labels:', plabels)
+        label_end = len(plabels)
+        vprint(5, 'Number of referenced labels:', label_end)
+        vprint(5, 'Compressed p steps:', compressed_proof)
+        vprint(5, 'Number of steps:', len(compressed_proof))
         proof_ints = []  # integers referencing the labels in 'labels'
         cur_int = 0  # counter for radix conversion
         for ch in compressed_proof:
@@ -474,9 +478,7 @@ class MM:
                 cur_int = 0
             else:  # 'U' <= ch <= 'Y'
                 cur_int = 5 * cur_int + ord(ch) - 84  # ord('U') = 85
-        vprint(5, 'proof_ints:', proof_ints)
-        label_end = len(plabels)
-        vprint(5, 'label_end:', label_end)
+        vprint(5, 'Integer-coded steps:', proof_ints)
         # Processing of the proof
         stack: list[Stmt] = []  # proof stack
         # statements saved for later reuse (marked with a 'Z')
@@ -540,7 +542,7 @@ class MM:
         if stack[0] != conclusion:
             raise MMError(("Stack entry {} does not match proved " +
                           " assertion {}.").format(stack[0], conclusion))
-        vprint(3, 'Correct proof.')
+        vprint(3, 'Correct proof!')
 
     def dump(self) -> None:
         """Print the labels of the database."""

--- a/mmverify.py
+++ b/mmverify.py
@@ -184,6 +184,17 @@ class FrameStack(list):
         return (dvs, f_hyps, e_hyps, stat)
 
 
+def apply_subst(stat, subst):
+    result = []
+    for tok in stat:
+        if tok in subst:
+            result.extend(subst[tok])
+        else:
+            result.append(tok)
+    vprint(20, 'apply_subst: ', stat, subst, ' = ', result)
+    return result
+
+
 class MM:
     def __init__(self, begin_label, stop_label):
         self.fs = FrameStack()
@@ -259,16 +270,6 @@ class MM:
                 print('Unknown token: ', tok)
             tok = toks.readc()
         self.fs.pop()
-
-    def apply_subst(self, stat, subst):
-        result = []
-        for tok in stat:
-            if tok in subst:
-                result.extend(subst[tok])
-            else:
-                result.append(tok)
-        vprint(20, 'apply_subst: ', stat, subst, ' = ', result)
-        return result
 
     def find_vars(self, stat):
         vars = []
@@ -382,14 +383,14 @@ class MM:
                                     x, y))
                 for h in e_hyps:
                     entry = stack[sp]
-                    subst_h = self.apply_subst(h, subst)
+                    subst_h = apply_subst(h, subst)
                     if entry != subst_h:
                         raise MMError(("stack entry {0!s} does not match " +
                                        "essential hypothesis {1!s}")
                                       .format(entry, subst_h))
                     sp += 1
                 del stack[len(stack) - npop:]
-                stack.append(self.apply_subst(result, subst))
+                stack.append(apply_subst(result, subst))
             elif steptyp in ('$e', '$f'):
                 stack.append(stepdat)
 

--- a/mmverify.py
+++ b/mmverify.py
@@ -59,7 +59,7 @@ class MMKeyError(MMError, KeyError):
     pass
 
 
-def vprint(vlevel: int, *args) -> None:
+def vprint(vlevel: int, *args: typing.Any) -> None:
     """Print log message if verbosity level is higher than the argument."""
     if verbosity >= vlevel:
         print(*args, file=logfile)
@@ -153,10 +153,10 @@ class Frame:
         self.f: list[Fhyp] = []
         self.f_labels: dict[Var, Label] = {}
         self.e: list[Ehyp] = []
-        self.e_labels: dict[tuple[Symbol], Label] = {}
+        self.e_labels: dict[tuple[Symbol, ...], Label] = {}
 
 
-class FrameStack(list):
+class FrameStack(list[Frame]):
     """Class of frame stacks, which extends lists (considered and used as
     stacks).
     """
@@ -430,7 +430,7 @@ class MM:
             stack.append(apply_subst(conclusion0, subst))
         vprint(12, 'stack:', stack)
 
-    def treat_normal_proof(self, proof) -> list[Stmt]:
+    def treat_normal_proof(self, proof: list[str]) -> list[Stmt]:
         """Return the proof stack once the given normal proof has been
         processed.
         """
@@ -443,7 +443,7 @@ class MM:
             self,
             f_hyps: list[Fhyp],
             e_hyps: list[Ehyp],
-            proof) -> list[Stmt]:
+            proof: list[str]) -> list[Stmt]:
         """Return the proof stack once the given compressed proof for an
         assertion with the given $f and $e-hypotheses has been processed.
         """
@@ -493,7 +493,7 @@ class MM:
             f_hyps: list[Fhyp],
             e_hyps: list[Ehyp],
             conclusion: Stmt,
-            proof) -> None:
+            proof: list[str]) -> None:
         """Verify that the given proof (in normal or compressed format) is a
         correct proof of the given assertion.
         """

--- a/mmverify.py
+++ b/mmverify.py
@@ -212,14 +212,6 @@ class MM:
                 self.fs.add_f(stat[1], stat[0], label)
                 self.labels[label] = ('$f', [stat[0], stat[1]])
                 label = None
-            elif tok == '$a':
-                if not label:
-                    raise MMError('$a must have label')
-                if label == self.stop_label:
-                    sys.exit(0)
-                self.labels[label] = ('$a',
-                                      self.fs.make_assertion(toks.readstat()))
-                label = None
             elif tok == '$e':
                 if not label:
                     raise MMError('$e must have label')
@@ -227,11 +219,23 @@ class MM:
                 self.fs.add_e(stat, label)
                 self.labels[label] = ('$e', stat)
                 label = None
+            elif tok == '$a':
+                if not label:
+                    raise MMError('$a must have label')
+                if label == self.stop_label:
+                    sys.exit(0)
+                if label == self.begin_label:
+                    self.begin_label = None
+                self.labels[label] = ('$a',
+                                      self.fs.make_assertion(toks.readstat()))
+                label = None
             elif tok == '$p':
                 if not label:
                     raise MMError('$p must have label')
                 if label == self.stop_label:
                     sys.exit(0)
+                if label == self.begin_label:
+                    self.begin_label = None
                 stat = toks.readstat()
                 proof = None
                 try:
@@ -240,8 +244,6 @@ class MM:
                     stat = stat[:i]
                 except ValueError:
                     raise MMError('$p must contain a proof after $=')
-                if self.begin_label and label == self.begin_label:
-                    self.begin_label = None
                 if not self.begin_label:
                     vprint(1, 'verifying: ', label)
                     self.verify(stat, proof)

--- a/mmverify.py
+++ b/mmverify.py
@@ -185,7 +185,7 @@ class FrameStack(list[Frame]):
             raise MMError('var already defined as const and active')
         self[-1].v.add(tok)
 
-    def add_f(self, var: Var, typecode: Const, label: Label) -> None:
+    def add_f(self, typecode: Const, var: Var, label: Label) -> None:
         """Add a floating hypothesis (ordered pair (variable, typecode)) to
         the frame stack top.
         """
@@ -321,7 +321,7 @@ class MM:
                 if len(stmt) != 2:
                     raise MMError('$f must have length 2')
                 vprint(15, label, '$f', stmt[0], stmt[1], '$.')
-                self.fs.add_f(stmt[1], stmt[0], label)
+                self.fs.add_f(stmt[0], stmt[1], label)
                 self.labels[label] = ('$f', [stmt[0], stmt[1]])
                 label = None
             elif tok == '$e':

--- a/mmverify.py
+++ b/mmverify.py
@@ -186,6 +186,7 @@ class FrameStack(list):
         frame = self[-1]
         frame.e.append(stat)
         frame.e_labels[tuple(stat)] = label
+        # conversion to tuple since dictionary keys must be hashable
 
     def add_d(self, stat):
         """Add a disjoint variable condition (ordered pair of variables) to

--- a/mmverify.py
+++ b/mmverify.py
@@ -1,28 +1,29 @@
 #!/usr/bin/env python3
-# mmverify.py -- Proof verifier for the Metamath language
-# Copyright (C) 2002 Raph Levien raph (at) acm (dot) org
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License
+"""mmverify.py -- Proof verifier for the Metamath language
+Copyright (C) 2002 Raph Levien raph (at) acm (dot) org
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License
 
-# To run the program, type
-#   $ python3 mmverify.py set.mm --logfile set.log
-# and set.log will have the verification results.  One can also use bash
-# redirections and type '$ python3 mmverify.py < set.mm 2> set.log' but this
-# would fail in case 'set.mm' contains (directly or not) a recursive inclusion
-# statement $[ set.mm $] .
-#
-# To get help on the program usage, type
-#   $ python3 mmverify.py -h
+To run the program, type
+  $ python3 mmverify.py set.mm --logfile set.log
+and set.log will have the verification results.  One can also use bash
+redirections and type '$ python3 mmverify.py < set.mm 2> set.log' but this
+would fail in case 'set.mm' contains (directly or not) a recursive inclusion
+statement $[ set.mm $] .
 
-# (nm 27-Jun-2005) mmverify.py requires that a $f hypothesis must not occur
-# after a $e hypothesis in the same scope, even though this is allowed by
-# the Metamath spec.  This is not a serious limitation since it can be
-# met by rearranging the hypothesis order.
-# (rl 2-Oct-2006) removed extraneous line found by Jason Orendorff
-# (sf 27-Jan-2013) ported to Python 3, added support for compressed proofs
-# and file inclusion
-# (bj 3-Apr-2022) streamline code and significant speedup (4x) by verifying
-# compressed proofs without converting them to normal format
+To get help on the program usage, type
+  $ python3 mmverify.py -h
+
+(nm 27-Jun-2005) mmverify.py requires that a $f hypothesis must not occur
+after a $e hypothesis in the same scope, even though this is allowed by
+the Metamath spec.  This is not a serious limitation since it can be
+met by rearranging the hypothesis order.
+(rl 2-Oct-2006) removed extraneous line found by Jason Orendorff
+(sf 27-Jan-2013) ported to Python 3, added support for compressed proofs
+and file inclusion
+(bj 3-Apr-2022) streamline code and significant speedup (4x) by verifying
+compressed proofs without converting them to normal format
+"""
 
 import sys
 import itertools

--- a/mmverify.py
+++ b/mmverify.py
@@ -234,9 +234,10 @@ class FrameStack(list):
                fr.d.intersection(itertools.product(mand_vars, mand_vars))}
         f_hyps = []
         # If one allows Metamath databases with multiple $f-statements for a
-        # given var, then one should use "reversed" in the next two lines to
-        # get the latest f_hyp corresponding to the given var.
-        # The current 'add_f' forbids such multiple $f-statements.
+        # given var, then one should use "reversed" in the next two lines and
+        # use 'appendleft' from 'collections.deque' to get the latest f_hyp
+        # corresponding to the given var.
+        # The current version of 'add_f' forbids such multiple $f-statements.
         for fr in self:
             for v, k in fr.f:
                 if v in mand_vars:

--- a/mmverify.py
+++ b/mmverify.py
@@ -43,9 +43,9 @@ Fhyp = tuple[Var, Const]
 Dv = tuple[Var, Var]
 Assertion = tuple[set[Dv], list[Fhyp], list[Ehyp], Stmt]
 FullStmt = tuple[Steptyp, typing.Union[Stmt, Assertion]]
-# actually, the second component of a FullStmt is a Stmt when its first
-# component is 'e' or 'f' and an Assertion if its first component is 'a' or
-# 'p', but this is a bit cumbersome to build it into the typing system.
+# Actually, the second component of a FullStmt is a Stmt when its first
+# component is '$e' or '$f' and an Assertion if its first component is '$a' or
+# '$p', but this is a bit cumbersome to build it into the typing system.
 # This explains the errors when static type checking (e.g., mypy).
 
 

--- a/mmverify.py
+++ b/mmverify.py
@@ -21,8 +21,9 @@ met by rearranging the hypothesis order.
 (rl 2-Oct-2006) removed extraneous line found by Jason Orendorff
 (sf 27-Jan-2013) ported to Python 3, added support for compressed proofs
 and file inclusion
-(bj 3-Apr-2022) streamline code and significant speedup (4x) by verifying
-compressed proofs without converting them to normal format
+(bj 3-Apr-2022) streamlined code; obtained significant speedup (4x on set.mm)
+by verifying compressed proofs without converting them to normal proof format;
+added type hints
 """
 
 import sys

--- a/mmverify.py
+++ b/mmverify.py
@@ -7,6 +7,8 @@
 # To run the program, type
 #   $ python3 mmverify.py < set.mm 2> set.log
 # and set.log will have the verification results.
+# To get help on the program usage, type
+#   $ python3 mmverify.py -h
 
 # (nm 27-Jun-2005) mmverify.py requires that a $f hypothesis must not occur
 # after a $e hypothesis in the same scope, even though this is allowed by
@@ -21,8 +23,6 @@ import itertools
 import collections
 import os.path
 import argparse
-
-verbosity = 1
 
 
 class MMError(Exception):
@@ -429,11 +429,35 @@ class MM:
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Verify a Metamth database.')
-    parser.add_argument('-b', '--begin-label', dest='begin_label',
-                        help='label to begin verifying (included)')
-    parser.add_argument('-s', '--stop-label', dest='stop_label',
-                        help='label to stop verifying (not included)')
+    parser.add_argument(
+        '-v',
+        '--verbosity',
+        dest='verbosity',
+        default=0,
+        type=int,
+        help='verbosity level')
+    parser.add_argument(
+        'file',
+        nargs='?',
+        type=argparse.FileType(
+            'r',
+            encoding='ascii'),
+        default=sys.stdin,
+        help='file to verify')
+    parser.add_argument(
+        '-b',
+        '--begin-label',
+        dest='begin_label',
+        type=str,
+        help='assertion label where to begin verifying (included)')
+    parser.add_argument(
+        '-s',
+        '--stop-label',
+        dest='stop_label',
+        type=str,
+        help='assertion label where to stop verifying (not included)')
     args = parser.parse_args()
+    verbosity = args.verbosity
     mm = MM(args.begin_label, args.stop_label)
-    mm.read(toks(sys.stdin))
+    mm.read(toks(args.file))
     # mm.dump()

--- a/mmverify.py
+++ b/mmverify.py
@@ -196,7 +196,7 @@ class FrameStack(list[Frame]):
         if any(var in fr.f_labels.keys() for fr in self):
             raise MMError('var in $f already typed by an active $f-statement')
         frame = self[-1]
-        frame.f.append((var, typecode))
+        frame.f.append((typecode, var))
         frame.f_labels[var] = label
 
     def add_e(self, stmt: Stmt, label: Label) -> None:
@@ -268,7 +268,7 @@ class FrameStack(list[Frame]):
                in fr.d if x in mand_vars and y in mand_vars}
         f_hyps = []
         for fr in self:
-            for var, typecode in fr.f:
+            for typecode, var in fr.f:
                 if var in mand_vars:
                     f_hyps.append((typecode, var))
                     mand_vars.remove(var)
@@ -391,13 +391,13 @@ class MM:
             if sp < 0:
                 raise MMError('stack underflow')
             subst: dict[Var, Stmt] = {}
-            for k, v in f_hyps0:
+            for typecode, var in f_hyps0:
                 entry = stack[sp]
-                if entry[0] != k:
+                if entry[0] != typecode:
                     raise MMError(
                         ("stack entry {2!s} does not match floating " +
-                         "hypothesis ({0}, {1})").format(entry, k, v))
-                subst[v] = entry[1:]
+                         "hypothesis ({0}, {1})").format(entry, typecode, var))
+                subst[var] = entry[1:]
                 sp += 1
             vprint(15, 'subst:', subst)
             for h in e_hyps0:

--- a/mmverify.py
+++ b/mmverify.py
@@ -466,7 +466,7 @@ class MM:
         vprint(5, 'Referenced labels:', plabels)
         label_end = len(plabels)
         vprint(5, 'Number of referenced labels:', label_end)
-        vprint(5, 'Compressed p steps:', compressed_proof)
+        vprint(5, 'Compressed proof steps:', compressed_proof)
         vprint(5, 'Number of steps:', len(compressed_proof))
         proof_ints = []  # integers referencing the labels in 'labels'
         cur_int = 0  # counter for radix conversion

--- a/mmverify.py
+++ b/mmverify.py
@@ -62,7 +62,7 @@ class toks:
             filename = self.read()
             endbracket = self.read()
             if endbracket != '$]':
-                raise MMError('Incusion command not terminated')
+                raise MMError('Inclusion command not terminated')
             filename = os.path.realpath(filename)
             if filename not in self.imported_files:
                 self.lines_buf.append(open(filename, 'r'))
@@ -206,7 +206,7 @@ class MM:
                 if not label:
                     raise MMError('$f must have label')
                 if len(stat) != 2:
-                    raise MMError('$f must have be length 2')
+                    raise MMError('$f must have length 2')
                 vprint(15, label, '$f', stat[0], stat[1], '$.')
                 self.fs.add_f(stat[1], stat[0], label)
                 self.labels[label] = ('$f', [stat[0], stat[1]])

--- a/mmverify.py
+++ b/mmverify.py
@@ -76,7 +76,8 @@ class toks:
             if tok == '$(':
                 while tok != '$)':
                     tok = self.read()
-            return tok
+            else:
+                return tok
 
     def readstat(self):
         stat = []
@@ -243,7 +244,7 @@ class MM:
                     self.begin_label = None
                 if not self.begin_label:
                     vprint(1, 'verifying: ', label)
-                    self.verify(label, stat, proof)
+                    self.verify(stat, proof)
                 self.labels[label] = ('$p', self.fs.make_assertion(stat))
                 label = None
             elif tok == '$d':
@@ -347,7 +348,7 @@ class MM:
 
         for label in proof:
             steptyp, stepdat = self.labels[label]
-            vprint(10, label, ': ', self.labels[label])
+            vprint(10, label, ': ', steptyp, stepdat)
 
             if steptyp in ('$a', '$p'):
                 dvs, f_hyps, e_hyps, result = stepdat

--- a/mmverify.py
+++ b/mmverify.py
@@ -73,7 +73,7 @@ class toks:
     def readc(self):
         while 1:
             tok = self.readf()
-            if tok == None:
+            if tok is None:
                 return None
             if tok == '$(':
                 while tok != '$)':
@@ -85,7 +85,7 @@ class toks:
         stat = []
         tok = self.readc()
         while tok != '$.':
-            if tok == None:
+            if tok is None:
                 raise MMError('EOF before $.')
             stat.append(tok)
             tok = self.readc()
@@ -274,7 +274,7 @@ class MM:
     def find_vars(self, stat):
         vars = []
         for x in stat:
-            if not x in vars and self.fs.lookup_v(x):
+            if x not in vars and self.fs.lookup_v(x):
                 vars.append(x)
         return vars
 
@@ -288,7 +288,7 @@ class MM:
         hyp_end = len(labels)
         ep = proof.index(')')
         labels += proof[1:ep]
-        compressed_proof = ''.join(proof[ep+1:])
+        compressed_proof = ''.join(proof[ep + 1:])
 
         vprint(5, 'labels:', labels)
         vprint(5, 'proof:', compressed_proof)
@@ -300,11 +300,11 @@ class MM:
             if ch == 'Z':
                 proof_ints.append(-1)
             elif 'A' <= ch and ch <= 'T':
-                cur_int = (20*cur_int + ord(ch) - ord('A') + 1)
+                cur_int = (20 * cur_int + ord(ch) - ord('A') + 1)
                 proof_ints.append(cur_int - 1)
                 cur_int = 0
             elif 'U' <= ch and ch <= 'Y':
-                cur_int = (5*cur_int + ord(ch) - ord('U') + 1)
+                cur_int = (5 * cur_int + ord(ch) - ord('U') + 1)
         vprint(5, 'proof_ints:', proof_ints)
 
         label_end = len(labels)

--- a/mmverify.py
+++ b/mmverify.py
@@ -448,13 +448,13 @@ class MM:
         assertion with the given $f and $e-hypotheses has been processed.
         """
         # Preprocessing and building the lists of proof_ints and labels
-        f_labels = [self.fs.lookup_f(v) for _, v in f_hyps]
-        e_labels = [self.fs.lookup_e(s) for s in e_hyps]
-        labels = f_labels + e_labels  # labels of implicit hypotheses
+        flabels = [self.fs.lookup_f(v) for _, v in f_hyps]
+        elabels = [self.fs.lookup_e(s) for s in e_hyps]
+        plabels = flabels + elabels  # labels of implicit hypotheses
         idx_bloc = proof.index(')')  # index of end of label bloc
-        labels += proof[1:idx_bloc]  # labels which will be referenced later
+        plabels += proof[1:idx_bloc]  # labels which will be referenced later
         compressed_proof = ''.join(proof[idx_bloc + 1:])
-        vprint(5, 'labels:', labels)
+        vprint(5, 'labels:', plabels)
         vprint(5, 'proof:', compressed_proof)
         proof_ints = []  # integers referencing the labels in 'labels'
         cur_int = 0  # counter for radix conversion
@@ -467,7 +467,7 @@ class MM:
             else:  # 'U' <= ch and ch <= 'Y'
                 cur_int = 5 * cur_int + ord(ch) - 84  # ord('U') = 85
         vprint(5, 'proof_ints:', proof_ints)
-        label_end = len(labels)
+        label_end = len(plabels)
         # Processing of the proof
         stack: list[Stmt] = []  # proof stack
         # statements saved for later reuse (marked with a 'Z')
@@ -479,7 +479,7 @@ class MM:
             elif 0 <= proof_int and proof_int < label_end:
                 # pf_int denotes an implicit hypothesis or a label in the label
                 # bloc
-                self.treat_step(self.labels[labels[proof_int]], stack)
+                self.treat_step(self.labels[plabels[proof_int]], stack)
             elif label_end <= proof_int:
                 # pf_int denotes an earlier proof step marked with a 'Z'
                 # A proof step that has already been proved can be treated as

--- a/mmverify.py
+++ b/mmverify.py
@@ -464,16 +464,21 @@ class MM:
         stack: list[Stmt] = []  # proof stack
         # statements saved for later reuse (marked with a 'Z')
         saved_stmts = []
+        # can be recovered as len(saved_stmts) but less efficient
+        n_saved_stmts = 0
         for proof_int in proof_ints:
             vprint(10, 'stack:', stack)
             if proof_int == -1:  # save the current step for later
                 saved_stmts.append(stack[-1])
-            elif 0 <= proof_int < label_end:
-                # pf_int denotes an implicit hypothesis or a label in the label
+                n_saved_stmts += 1
+            elif proof_int < label_end:
+                # proof_int denotes an implicit hypothesis or a label in the label
                 # bloc
                 self.treat_step(self.labels[plabels[proof_int]], stack)
-            elif label_end <= proof_int:
-                # pf_int denotes an earlier proof step marked with a 'Z'
+            elif proof_int > n_saved_stmts:
+                MMError("Not enough saved subproofs.")
+            else:  # label_end <= proof_int <= n_saved_stmts
+                # proof_int denotes an earlier proof step marked with a 'Z'
                 # A proof step that has already been proved can be treated as
                 # a dv-free and hypothesis-free axiom.
                 self.treat_step(

--- a/mmverify.py
+++ b/mmverify.py
@@ -378,7 +378,7 @@ class MM:
         vprint(5, 'proof_ints:', proof_ints)
         label_end = len(labels)
         decompressed_ints = []
-        subproofs = []
+        subproofs = []  # proofs that are referenced later (marked by a 'Z')
         prev_proofs = []
         for pf_int in proof_ints:
             if pf_int == -1:

--- a/mmverify.py
+++ b/mmverify.py
@@ -179,7 +179,7 @@ class FrameStack(list):
                     f_hyps.appendleft((k, v))
                     mand_vars.remove(v)
 
-        vprint(18, 'ma:', (dvs, f_hyps, e_hyps, stat))
+        vprint(18, 'make_assertion: ', dvs, f_hyps, e_hyps, stat)
         return (dvs, f_hyps, e_hyps, stat)
 
 
@@ -207,7 +207,7 @@ class MM:
                     raise MMError('$f must have label')
                 if len(stat) != 2:
                     raise MMError('$f must have length 2')
-                vprint(15, label, '$f', stat[0], stat[1], '$.')
+                vprint(15, label, '$f ', stat[0], stat[1], ' $.')
                 self.fs.add_f(stat[1], stat[0], label)
                 self.labels[label] = ('$f', [stat[0], stat[1]])
                 label = None
@@ -238,11 +238,11 @@ class MM:
                     proof = stat[i + 1:]
                     stat = stat[:i]
                 except ValueError:
-                    raise MMError('$p must contain proof after $=')
+                    raise MMError('$p must contain a proof after $=')
                 if self.begin_label and label == self.begin_label:
                     self.begin_label = None
                 if not self.begin_label:
-                    vprint(1, 'verifying', label)
+                    vprint(1, 'verifying: ', label)
                     self.verify(label, stat, proof)
                 self.labels[label] = ('$p', self.fs.make_assertion(stat))
                 label = None
@@ -253,7 +253,7 @@ class MM:
             elif tok[0] != '$':
                 label = tok
             else:
-                print('tok:', tok)
+                print('Unknown token: ', tok)
             tok = toks.readc()
         self.fs.pop()
 
@@ -264,7 +264,7 @@ class MM:
                 result.extend(subst[tok])
             else:
                 result.append(tok)
-        vprint(20, 'apply_subst', (stat, subst), '=', result)
+        vprint(20, 'apply_subst: ', stat, subst, ' = ', result)
         return result
 
     def find_vars(self, stat):
@@ -275,19 +275,19 @@ class MM:
         return vars
 
     def decompress_proof(self, stat, proof):
-        dm, mand_hyp_stmts, hyp_stmts, stat = self.fs.make_assertion(stat)
+        _, f_hyps, e_hyps, stat = self.fs.make_assertion(stat)
 
-        mand_hyps = [self.fs.lookup_f(v) for k, v in mand_hyp_stmts]
-        hyps = [self.fs.lookup_e(s) for s in hyp_stmts]
+        f_labels = [self.fs.lookup_f(v) for k, v in f_hyps]
+        e_labels = [self.fs.lookup_e(s) for s in e_hyps]
 
-        labels = mand_hyps + hyps
+        labels = f_labels + e_labels
         hyp_end = len(labels)
         ep = proof.index(')')
         labels += proof[1:ep]
         compressed_proof = ''.join(proof[ep + 1:])
 
-        vprint(5, 'labels:', labels)
-        vprint(5, 'proof:', compressed_proof)
+        vprint(5, 'labels: ', labels)
+        vprint(5, 'proof: ', compressed_proof)
 
         proof_ints = []
         cur_int = 0
@@ -301,7 +301,7 @@ class MM:
                 cur_int = 0
             elif 'U' <= ch and ch <= 'Y':
                 cur_int = (5 * cur_int + ord(ch) - ord('U') + 1)
-        vprint(5, 'proof_ints:', proof_ints)
+        vprint(5, 'proof_ints: ', proof_ints)
 
         label_end = len(labels)
         decompressed_ints = []
@@ -325,7 +325,7 @@ class MM:
                         new_prevpf = [s for p in prev_proofs[-nshyps:]
                                       for s in p] + [pf_int]
                         prev_proofs = prev_proofs[:-nshyps]
-                        vprint(5, 'nshyps:', nshyps)
+                        vprint(5, 'nshyps: ', nshyps)
                     else:
                         new_prevpf = [pf_int]
                     prev_proofs.append(new_prevpf)
@@ -333,10 +333,10 @@ class MM:
                     prev_proofs.append([pf_int])
             elif label_end <= pf_int:
                 pf = subproofs[pf_int - label_end]
-                vprint(5, 'expanded subpf:', pf)
+                vprint(5, 'expanded subpf: ', pf)
                 decompressed_ints += pf
                 prev_proofs.append(pf)
-        vprint(5, 'decompressed ints:', decompressed_ints)
+        vprint(5, 'decompressed ints: ', decompressed_ints)
 
         return [labels[i] for i in decompressed_ints]
 
@@ -347,41 +347,42 @@ class MM:
 
         for label in proof:
             steptyp, stepdat = self.labels[label]
-            vprint(10, label, ':', self.labels[label])
+            vprint(10, label, ': ', self.labels[label])
 
             if steptyp in ('$a', '$p'):
-                (distinct, mand_var, hyp, result) = stepdat
+                dvs, f_hyps, e_hyps, result = stepdat
                 vprint(12, stepdat)
-                npop = len(mand_var) + len(hyp)
+                npop = len(f_hyps) + len(e_hyps)
                 sp = len(stack) - npop
                 if sp < 0:
                     raise MMError('stack underflow')
                 subst = {}
-                for (k, v) in mand_var:
+                for (k, v) in f_hyps:
                     entry = stack[sp]
                     if entry[0] != k:
                         raise MMError(
-                            ("stack entry ({0}, {1}) doesn't match " +
-                             "mandatory var hyp {2!s}").format(k, v, entry))
+                            ("stack entry ({0}, {1}) does not match " +
+                             "floating hypothesis {2!s}").format(k, v, entry))
                     subst[v] = entry[1:]
                     sp += 1
-                vprint(15, 'subst:', subst)
-                for x, y in distinct:
-                    vprint(16, 'dist', x, y, subst[x], subst[y])
+                vprint(15, 'subst: ', subst)
+                for x, y in dvs:
+                    vprint(16, 'dist ', x, y, subst[x], subst[y])
                     x_vars = self.find_vars(subst[x])
                     y_vars = self.find_vars(subst[y])
-                    vprint(16, 'V(x) =', x_vars)
-                    vprint(16, 'V(y) =', y_vars)
+                    vprint(16, 'V(x) = ', x_vars)
+                    vprint(16, 'V(y) = ', y_vars)
                     for x, y in itertools.product(x_vars, y_vars):
                         if x == y or not self.fs.lookup_d(x, y):
-                            raise MMError("disjoint violation: {0}, {1}"
-                                          .format(x, y))
-                for h in hyp:
+                            raise MMError(
+                                "disjoint variable violation: {0}, {1}" .format(
+                                    x, y))
+                for h in e_hyps:
                     entry = stack[sp]
                     subst_h = self.apply_subst(h, subst)
                     if entry != subst_h:
-                        raise MMError(("stack entry {0!s} doesn't match " +
-                                       "hypothesis {1!s}")
+                        raise MMError(("stack entry {0!s} does not match " +
+                                       "essential hypothesis {1!s}")
                                       .format(entry, subst_h))
                     sp += 1
                 del stack[len(stack) - npop:]
@@ -389,11 +390,11 @@ class MM:
             elif steptyp in ('$e', '$f'):
                 stack.append(stepdat)
 
-            vprint(12, 'st:', stack)
+            vprint(12, 'stack: ', stack)
         if len(stack) != 1:
-            raise MMError('stack has >1 entry at end')
+            raise MMError('Stack has more than one entry at the end')
         if stack[0] != stat:
-            raise MMError("assertion proved doesn't match")
+            raise MMError("Assertion proved does not match")
 
     def dump(self): print(self.labels)
 

--- a/mmverify.py
+++ b/mmverify.py
@@ -481,8 +481,8 @@ class MM:
                     stack[0],
                     conclusion))
         if stack[0] != conclusion:
-            raise MMError("Stack entry {0!s} does not match proved " +
-                          " assertion {1!s}".format(stack[0], conclusion))
+            raise MMError(("Stack entry {0!s} does not match proved " +
+                          " assertion {1!s}").format(stack[0], conclusion))
 
     def dump(self):
         """Print the labels of the database."""


### PR DESCRIPTION
This could subsume PR #6. In addition to it (described in #4), it achieves a 3 to 4 times speedup by verifying compressed proofs directly without converting them to normal format.

Also some bug fixes (including the one mentionned in https://github.com/metamath/metamath-exe/issues/81) and code documentation.

This could be used in https://github.com/metamath/set.mm/blob/develop/.github/workflows/verifiers.yml: probably no need to split set.mm into main/mathbox thanks to speedup, and also one should probably use normal arguments instead of bash redirections to avoid the bug described in https://github.com/metamath/metamath-exe/issues/81.