### PR TITLE
make constants global

### DIFF
--- a/mmverify.py
+++ b/mmverify.py
@@ -307,7 +307,7 @@ class MM:
 
     def add_v(self, tok: Var) -> None:
         """Add a variable to the frame stack top (that is, the current frame)
-        of the database.  Allow local definitions.
+        of the database.  Allow local variable declarations.
         """
         if self.fs.lookup_v(tok):
             raise MMError('var already declared and active: {}'.format(tok))
@@ -318,7 +318,7 @@ class MM:
 
     def add_f(self, typecode: Const, var: Var, label: Label) -> None:
         """Add a floating hypothesis (ordered pair (variable, typecode)) to
-        the frame stack top.
+        the frame stack top (that is, the current frame) of the database.
         """
         if not self.fs.lookup_v(var):
             raise MMError('var in $f not declared: {}'.format(var))

--- a/mmverify.py
+++ b/mmverify.py
@@ -313,7 +313,7 @@ class MM:
             raise MMError('var already declared and active: {}'.format(tok))
         if tok in self.constants:
             raise MMError(
-                'var already declared as const and active: {}'.format(tok))
+                'var already declared as constant: {}'.format(tok))
         self.fs[-1].v.add(tok)
 
     def add_f(self, typecode: Const, var: Var, label: Label) -> None:
@@ -322,7 +322,7 @@ class MM:
         """
         if not self.fs.lookup_v(var):
             raise MMError('var in $f not declared: {}'.format(var))
-        if not typecode in self.constants:
+        if typecode not in self.constants:
             raise MMError('typecode in $f not declared: {}'.format(typecode))
         if any(var in fr.f_labels.keys() for fr in self.fs):
             raise MMError(


### PR DESCRIPTION
Constants had local scope, contrary to the specification. This PR makes constant declarations global: wherever they are declared, once they are declared, they stay active forever. As said in the Metamath book, this is necessary, since $a and $p statements stay forever active (they may be used by any later proof), so their statements have to keep the same meaning forever.

BEFORE MERGING, question to anyone, maybe @tirix or @digama0 : to make constants global, I added a field to the class of databases (the set `self.constants` in class `MM`). I then had to move add_c, add_v, add_f from being FrameStack methods to being MM methods (since they need to know the set of declared constants). I could have left them as FrameStack methods and added to them an argument `constants` that is passed when these methods are called in the MM class. I thought the present choice is more natural, but maybe more experienced programmers have an advice concerning these issues ?