### PR TITLE
add active/typed checks

### DIFF
--- a/mmverify.py
+++ b/mmverify.py
@@ -420,6 +420,8 @@ class MM:
             elif tok == '$)':
                 raise MMError("Unexpected '$)' while not within a comment")
             elif tok[0] != '$':
+                if tok in self.labels:
+                    raise MMError("Label {} multiply defined.".format(tok))
                 label = tok
                 vprint(20, 'Label:', label)
                 if label == self.stop_label:

--- a/mmverify.py
+++ b/mmverify.py
@@ -328,15 +328,17 @@ class MM:
             if tok == '$=':
                 stmt_part = False
             is_active_var = self.fs.lookup_v(tok)
-            if str in {'$d', '$e', '$a', '$p'} and stmt_part and not (
-                    tok in self.constants or is_active_var):
-                raise MMError("Token {} is not an active symbol".format(tok))
-            if str in {
-                '$e',
-                '$a',
-                    '$p'} and is_active_var and stmt_part and not self.fs.lookup_f(tok):
-                raise MMError(("Variable {} in {}-statement is not typed " +
-                               "by an active $f-statement).").format(tok, str))
+            if stmt_part:
+                if str in {'$d', '$e', '$a', '$p'} and not (
+                        tok in self.constants or is_active_var):
+                    raise MMError(
+                        "Token {} is not an active symbol".format(tok))
+                if str in {
+                        '$e',
+                        '$a',
+                        '$p'} and is_active_var and not self.fs.lookup_f(tok):
+                    raise MMError(("Variable {} in {}-statement is not typed " +
+                                   "by an active $f-statement).").format(tok, str))
             if not tok:
                 raise MMError(
                     "Unclosed {}-statement at end of file.".format(str))

--- a/mmverify.py
+++ b/mmverify.py
@@ -335,7 +335,7 @@ class MM:
                 '$e',
                 '$a',
                     '$p'} and is_active_var and stmt_part and not self.fs.lookup_f(tok):
-                raise MMError(("Variable {} in {}-statement is not typed" +
+                raise MMError(("Variable {} in {}-statement is not typed " +
                                "by an active $f-statement).").format(tok, str))
             if not tok:
                 raise MMError(


### PR DESCRIPTION
* check that all symbols are active in an $eapd-statement
* check that all variables are (actively) typed in an $eap-statement

These checks are added in order to follow the specification more closely. Bug was reported in https://groups.google.com/g/metamath/c/PAm7YQb2qkw/m/OcDhSoCFAgAJ

There is a bit of code repetition since the `readstmt` method can now tell if one is reading before $= or after it, but this fact is recomputed later. One could code a general method `read_eapd_stmt` with an `end_tokens` argument (typically, either {'$.'} or {'$=', '$.'}), and then methods using it: `read_ea_stmt`, `read_d_stmt`, `read_p_stmt`, with the latter returning a couple (stmt, proof).

Requiring that all variables in a $d-statement be typed as well would simplify the specification a bit. Removing $v altogether would simplify the specification further (since then, for a variable, being active and being typed would be one and the same thing). This change would be backward compatible (in that databases complying with the old specification would comply with the new one). Thoughts ? @tirix @digama0 ?