### PR TITLE
Clarify license statements

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 David A. Wheeler
+Copyright (c) Raph Levien, David A. Wheeler, and the mmverify.py contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/mmverify.py
+++ b/mmverify.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 """mmverify.py -- Proof verifier for the Metamath language
 Copyright (C) 2002 Raph Levien raph (at) acm (dot) org
-# This program is free software distributed under the MIT license;
-# see the file LICENSE for full license information.
+Copyright (C) David A. Wheeler and mmverify.py contributors
+
+This program is free software distributed under the MIT license;
+see the file LICENSE for full license information.
+SPDX-License-Identifier: MIT
 
 To run the program, type
   $ python3 mmverify.py set.mm --logfile set.log


### PR DESCRIPTION
Clarify the license statements. We don't need everyone listed
in the license statements (we have a version control system for that).
For recommendations, see:
https://www.linuxfoundation.org/blog/copyright-notices-in-open-source-software-projects/

This includes the SPDX-License-Identifier information. For more info see:
https://github.com/david-a-wheeler/spdx-tutorial

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>