### PR TITLE
Inclusions

### DIFF
--- a/mmverify.py
+++ b/mmverify.py
@@ -161,7 +161,8 @@ class Toks:
             if not tok:
                 raise MMError("Unclosed comment at end of file.")
             assert(tok == '$)')
-            tok = self.read()
+            # 'readf' since an inclusion may follow a comment immediately
+            tok = self.readf()
         vprint(70, "Token once comments skipped:", tok)
         return tok
 
@@ -439,7 +440,7 @@ class MM:
                 if label == self.begin_label:
                     self.verify_proofs = True
             else:
-                raise MMError("Unknown token: {}.".format(tok))
+                raise MMError("Unknown token: '{}'.".format(tok))
             tok = toks.readc()
         self.fs.pop()
 


### PR DESCRIPTION
* fix bug (introduced by me) when an inclusion immediately follows a comment
* fix bug when an inclusion command does not end a line
* now raise on unclosed ${...$} block
* add some comments and rename some variables for consistency and clarity

@david-a-wheeler : except for the one signaled above, bugs and imprecisions were pre-existing (not introduced by me).

As with previous PR's, I checked the code with
```
$ autopep8 -i -a -a -a mmverify.py
$ mypy mmverify.py --strict
$ pylint mmverify.py
```
(a few warnings explained in code comments).
