### PR TITLE
Added a missing 'raise' before an MMError.

### DIFF
--- a/mmverify.py
+++ b/mmverify.py
@@ -585,7 +585,7 @@ class MM:
                 # label bloc
                 self.treat_step(self.labels[plabels[proof_int] or ''], stack)
             elif proof_int >= label_end + n_saved_stmts:
-                MMError(
+                raise MMError(
                     ("Not enough saved proof steps ({} saved but calling " +
                     "the {}th).").format(
                         n_saved_stmts,


### PR DESCRIPTION
Codex found a missing raise statement.

The following .mm file discriminates the fix.  Please feel free to adapt it to suite appropriate style guidelines.

```
$c |- T $.

ax     $a |- T $.
buggy  $p |- T $= ( ax ) A Z C $.
```

Test case has also been added to the metamath-test suite: https://github.com/david-a-wheeler/metamath-test/pull/6