### PR TITLE
Illegal label fix and missing raise MMError added

### DIFF
--- a/mmverify.py
+++ b/mmverify.py
@@ -585,7 +585,7 @@ class MM:
                 # label bloc
                 self.treat_step(self.labels[plabels[proof_int] or ''], stack)
             elif proof_int >= label_end + n_saved_stmts:
-                MMError(
+                raise MMError(
                     ("Not enough saved proof steps ({} saved but calling " +
                     "the {}th).").format(
                         n_saved_stmts,


### PR DESCRIPTION
1) "A label token consists of any combination of letters, digits, and the characters hyphen, underscore, and period." (Metamath.pdf section 4.1.1)

The old version allows labels such as t\t.

2) Codex found a missing raise statement.

The following .mm file discriminates the fix. Please feel free to adapt it to suite appropriate style guidelines.

```
$c |- T $.

ax     $a |- T $.
buggy  $p |- T $= ( ax ) A Z C $.
```

Test cases have also been added to the metamath-test suite: https://github.com/david-a-wheeler/metamath-test/pull/6
