### PR TITLE
Fix of math symbols allowing $, labels allowing illegal tokens (e.g., t\t), and a missing 'raise' before an MMError

### DIFF
--- a/mmverify.py
+++ b/mmverify.py
@@ -310,6 +310,8 @@ class MM:
 
     def add_c(self, tok: Const) -> None:
         """Add a constant to the database."""
+        if '$' in tok:
+            raise MMError("Character '$' not allowed in math symbol: {}".format(tok))
         if tok in self.constants:
             raise MMError(
                 'Constant already declared: {}'.format(tok))
@@ -322,6 +324,8 @@ class MM:
         """Add a variable to the frame stack top (that is, the current frame)
         of the database.  Allow local variable declarations.
         """
+        if '$' in tok:
+            raise MMError("Character '$' not allowed in math symbol: {}".format(tok))
         if self.fs.lookup_v(tok):
             raise MMError('var already declared and active: {}'.format(tok))
         if tok in self.constants:

--- a/mmverify.py
+++ b/mmverify.py
@@ -585,7 +585,7 @@ class MM:
                 # label bloc
                 self.treat_step(self.labels[plabels[proof_int] or ''], stack)
             elif proof_int >= label_end + n_saved_stmts:
-                MMError(
+                raise MMError(
                     ("Not enough saved proof steps ({} saved but calling " +
                     "the {}th).").format(
                         n_saved_stmts,


### PR DESCRIPTION
1) "A label token consists of any combination of letters, digits, and the characters hyphen, underscore, and period." (Metamath.pdf section 4.1.1)

The old version allows labels such as t\t.

2) math symbols allowed $, which is not permitted.

3) Codex found a missing raise statement.

The following .mm file discriminates the fix. Please feel free to adapt it to suite appropriate style guidelines.

```
$c |- T $.

ax     $a |- T $.
buggy  $p |- T $= ( ax ) A Z C $.
```

Test cases have also been added to the metamath-test suite: https://github.com/david-a-wheeler/metamath-test/pull/6
